### PR TITLE
<#13> feat: swagger 의존성 및 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,11 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    // swagger
+    implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+    implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
+
 }
 
 test {

--- a/src/main/java/com/j2kb/minipetpee/SwaggerConfig.java
+++ b/src/main/java/com/j2kb/minipetpee/SwaggerConfig.java
@@ -1,0 +1,37 @@
+package com.j2kb.minipetpee;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+    // Web Page Test
+    // {host}/swagger-ui.html
+
+    @Bean
+    public Docket restAPI() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .apiInfo(apiInfo())
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.j2kb.minipetpee")) // 대상 패키지 설정
+                .paths(PathSelectors.any()) // 모든 경로의 api 출력
+                .build();
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("Minipetpee API")
+                .version("1.0.0")
+                .description("Minipetpee Backend Spring Boot Rest API")
+                .build();
+    }
+}


### PR DESCRIPTION
# 이슈
#13 

# 변경사항
- build.gradle: swagger 및 swagger-ui 의존성 추가
- SwaggerConfig.java: swagger 설정
    - basePackage: 프로젝트 최상단 패키지로 설정
    - path: 모든 하위 경로의 api 출력되도록 설정

# 확인
`http://{ 호스트 }/swagger-ui.html`

# 기타
- 현재 db 세팅 안 되어 `application.yaml`이나 `application.properties` 설정 파일에 db 연동 관련 내용 추가해주어야 확인할 수 있습니다!
- 프론트분들이 쓰시냐고 여쭤보셔서 추가해봤는데 틀렸거나 필요 없으면 팽해주세요....