### PR TITLE
<#40> fix: MemberRepository 중복 에러 수정

### DIFF
--- a/src/main/java/com/j2kb/minipetpee/api/guestnote/service/GuestNoteService.java
+++ b/src/main/java/com/j2kb/minipetpee/api/guestnote/service/GuestNoteService.java
@@ -6,7 +6,7 @@ import com.j2kb.minipetpee.api.guestnote.domain.GuestNote;
 import com.j2kb.minipetpee.api.guestnote.repository.GuestNoteRepository;
 import com.j2kb.minipetpee.api.homepee.repository.HomepeeRepository;
 import com.j2kb.minipetpee.api.member.domain.Member;
-import com.j2kb.minipetpee.api.member.domain.repository.MemberRepository;
+import com.j2kb.minipetpee.api.member.repository.MemberRepository;
 import com.j2kb.minipetpee.api.setting.domain.Tab;
 import com.j2kb.minipetpee.api.setting.domain.Type;
 import com.j2kb.minipetpee.api.setting.repository.TabRepository;

--- a/src/main/java/com/j2kb/minipetpee/api/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/j2kb/minipetpee/api/member/domain/repository/MemberRepository.java
@@ -1,7 +1,0 @@
-package com.j2kb.minipetpee.api.member.domain.repository;
-
-import com.j2kb.minipetpee.api.member.domain.Member;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface MemberRepository extends JpaRepository<Member, Long> {
-}


### PR DESCRIPTION
# 설명
member 레포지토리가 도메인 패키지 안에 들어가 있어서 수정했습니다~

# 내용
- 파일 제거: /api/member/domain/repository/MemberRepository.java
- GuestNoteService 내 import 경로 수정